### PR TITLE
Can now add temporary effects on unit stats

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/main/java/com/whbattle/springboot/adapter/controller/BattleReportController.java
+++ b/src/main/java/com/whbattle/springboot/adapter/controller/BattleReportController.java
@@ -21,10 +21,10 @@ public class BattleReportController {
     }
 
     @PostMapping("/battle_report")
-    public ResponseEntity createBattleRapport(
+    public ResponseEntity<String> createBattleRapport(
             @RequestBody UnitDto[] units) {
 
         BattleReport battleReport = createBattleReport.create(units);
-        return new ResponseEntity<String>(battleReport.battleReportMessage(), HttpStatus.OK);
+        return new ResponseEntity<>(battleReport.battleReportMessage(), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/whbattle/springboot/domain/entity/battleReport/BattleReport.java
+++ b/src/main/java/com/whbattle/springboot/domain/entity/battleReport/BattleReport.java
@@ -5,20 +5,24 @@ import com.whbattle.springboot.domain.entity.unit.Unit;
 public class BattleReport {
 
     public float probabilityOfWinning;
+    public float averageRemainingModels;
     public Unit friendlyUnit;
     public Unit enemyUnit;
 
-    public BattleReport(float probabilityOfWinning, Unit friendlyUnit, Unit enemyUnit) {
+    public BattleReport(float probabilityOfWinning, float averageRemainingModels, Unit friendlyUnit, Unit enemyUnit) {
         this.probabilityOfWinning = probabilityOfWinning;
+        this.averageRemainingModels = averageRemainingModels;
         this.friendlyUnit = friendlyUnit;
         this.enemyUnit = enemyUnit;
     }
 
-    public String battleReportMessage(){
-        return "The probability of " +
-                this.friendlyUnit.getNumber() +  " " + this.friendlyUnit.getName() +
-                " to win against " +
-                this.enemyUnit.getNumber() + " " + this.enemyUnit.getName() +
-                " are approximately : " + this.probabilityOfWinning * 100 + "%";
+    public String battleReportMessage() {
+        return String.format("The probability of %s winning against %s is approximately %s.\n" +
+                        "On average, there are %s surviving models.",
+                this.friendlyUnit.getNumber() + " " + this.friendlyUnit.getName(),
+                this.enemyUnit.getNumber() + " " + this.enemyUnit.getName(),
+                this.probabilityOfWinning * 100 + "%",
+                Math.round(this.averageRemainingModels)
+        );
     }
 }

--- a/src/main/java/com/whbattle/springboot/domain/entity/unit/Effect.java
+++ b/src/main/java/com/whbattle/springboot/domain/entity/unit/Effect.java
@@ -1,0 +1,40 @@
+package com.whbattle.springboot.domain.entity.unit;
+
+public class Effect {
+    private final int toHitModifier;
+    private final int toWoundModifier;
+    private final int startTurn;
+    private final int endTurn;
+    private boolean active = false;
+
+    public Effect(int toHitModifier, int toWoundModifier, int startTurn, int endTurn) {
+        this.toHitModifier = toHitModifier;
+        this.toWoundModifier = toWoundModifier;
+        this.startTurn = startTurn;
+        this.endTurn = endTurn;
+    }
+
+    public int getToHitModifier() {
+        return toHitModifier;
+    }
+
+    public int getToWoundModifier() {
+        return toWoundModifier;
+    }
+
+    public int getStartTurn() {
+        return startTurn;
+    }
+
+    public int getEndTurn() {
+        return endTurn;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/src/main/java/com/whbattle/springboot/usecase/battlereport/CreateBattleReport.java
+++ b/src/main/java/com/whbattle/springboot/usecase/battlereport/CreateBattleReport.java
@@ -8,7 +8,10 @@ import com.whbattle.springboot.usecase.unit.dto.UnitMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 @Component
 public class CreateBattleReport {
@@ -16,47 +19,58 @@ public class CreateBattleReport {
     private final UnitMapper unitMapper;
 
     @Autowired
-    public CreateBattleReport(UnitMapper unitMapper){
+    public CreateBattleReport(UnitMapper unitMapper) {
         this.unitMapper = unitMapper;
     }
 
     public BattleReport create(UnitDto[] unitDtos) {
         int nbOfWin = 0;
+        int nbOfSurvivors = 0;
         int NUMBER_OF_BATTLE = 10000;
         Unit[] units = unitMapper.mapUnitList(unitDtos);
 
-
         for (int i = 0; i < NUMBER_OF_BATTLE; i++) {
-            List<Unit> shuffledList = this.cloneUnits(units);
-            Collections.shuffle(shuffledList, new Random());
+            List<Unit> shuffledUnits = this.cloneUnits(unitMapper.mapUnitList(unitDtos));
+            Collections.shuffle(shuffledUnits, new Random());
 
-            Unit winner = this.battle(shuffledList);
+            Unit winner = this.battle(shuffledUnits);
             if (winner.getName().equals(units[0].getName())) {
                 nbOfWin++;
+                nbOfSurvivors += winner.getNumber();
             }
         }
 
-        float probability = (float) nbOfWin/NUMBER_OF_BATTLE;
-        return new BattleReport(probability, units[0], units[1]);
+        float probability = (float) nbOfWin / NUMBER_OF_BATTLE;
+        float averageSurvivingModels = (float) nbOfSurvivors / NUMBER_OF_BATTLE;
+        return new BattleReport(probability, averageSurvivingModels, units[0], units[1]);
     }
 
     public Unit battle(List<Unit> units) {
         Unit winner = null;
+        int currentTurn = 0;
 
-        while(units.size() >= 2) {
-            Attack attack = units.get(0).rollAttacks();
-            units.get(1).resolveDamage(attack);
+        Unit unit1 = units.get(0);
+        Unit unit2 = units.get(1);
 
-            if (units.get(1).isDead()) {
-                winner = units.get(0);
+        while (units.size() >= 2) {
+            currentTurn++;
+
+            unit1.updateEffects(currentTurn);
+            unit2.updateEffects(currentTurn);
+
+            Attack attack = unit1.rollAttacks();
+            unit2.resolveDamage(attack);
+
+            if (unit2.isDead()) {
+                winner = unit1;
                 break;
             }
 
-            attack = units.get(1).rollAttacks();
-            units.get(0).resolveDamage(attack);
+            attack = unit2.rollAttacks();
+            unit1.resolveDamage(attack);
 
-            if (units.get(0).isDead()) {
-                winner = units.get(1);
+            if (unit1.isDead()) {
+                winner = unit2;
                 break;
             }
         }
@@ -67,7 +81,7 @@ public class CreateBattleReport {
     private List<Unit> cloneUnits(Unit[] units) {
         List<Unit> resultList = new ArrayList<>();
 
-        for(Unit unit: units) {
+        for (Unit unit : units) {
             resultList.add(unit.clone());
         }
 

--- a/src/main/java/com/whbattle/springboot/usecase/effect/dto/dto/EffectDto.java
+++ b/src/main/java/com/whbattle/springboot/usecase/effect/dto/dto/EffectDto.java
@@ -1,0 +1,8 @@
+package com.whbattle.springboot.usecase.effect.dto.dto;
+
+public class EffectDto {
+    public int toHitModifier;
+    public int toWoundModifier;
+    public int startTurn;
+    public int endTurn;
+}

--- a/src/main/java/com/whbattle/springboot/usecase/effect/dto/dto/EffectMapper.java
+++ b/src/main/java/com/whbattle/springboot/usecase/effect/dto/dto/EffectMapper.java
@@ -1,0 +1,31 @@
+package com.whbattle.springboot.usecase.effect.dto.dto;
+
+import com.whbattle.springboot.domain.entity.unit.Effect;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class EffectMapper {
+    public Effect mapEffect(EffectDto effectDto) {
+        return new Effect(
+                effectDto.toHitModifier,
+                effectDto.toWoundModifier,
+                effectDto.startTurn,
+                effectDto.endTurn
+        );
+    }
+
+    public List<Effect> mapEffectList(EffectDto[] effectDtos) {
+        List<Effect> effects = new ArrayList<>();
+
+        if (effectDtos == null) return effects;
+
+        for (EffectDto effectDto : effectDtos) {
+            effects.add(this.mapEffect(effectDto));
+        }
+
+        return effects;
+    }
+}

--- a/src/main/java/com/whbattle/springboot/usecase/unit/dto/UnitDto.java
+++ b/src/main/java/com/whbattle/springboot/usecase/unit/dto/UnitDto.java
@@ -1,14 +1,16 @@
 package com.whbattle.springboot.usecase.unit.dto;
 
 import com.whbattle.springboot.domain.entity.dice.ReRoll;
+import com.whbattle.springboot.usecase.effect.dto.dto.EffectDto;
 import com.whbattle.springboot.usecase.weapon.dto.WeaponDto;
 
 public class UnitDto {
-        public String name;
-        public int number;
-        public int save;
-        public int wound;
-        public int totalWounds;
-        public WeaponDto weapon;
-        public ReRoll reRoll;
+    public String name;
+    public int number;
+    public int save;
+    public int wound;
+    public int totalWounds;
+    public WeaponDto weapon;
+    public ReRoll reRoll;
+    public EffectDto[] effects;
 }

--- a/src/main/java/com/whbattle/springboot/usecase/unit/dto/UnitMapper.java
+++ b/src/main/java/com/whbattle/springboot/usecase/unit/dto/UnitMapper.java
@@ -2,12 +2,17 @@ package com.whbattle.springboot.usecase.unit.dto;
 
 import com.whbattle.springboot.domain.entity.dice.DiceRoller;
 import com.whbattle.springboot.domain.entity.dice.Die;
+import com.whbattle.springboot.domain.entity.unit.Effect;
 import com.whbattle.springboot.domain.entity.unit.Unit;
 import com.whbattle.springboot.domain.entity.unit.weapon.Weapon;
+import com.whbattle.springboot.usecase.effect.dto.dto.EffectDto;
+import com.whbattle.springboot.usecase.effect.dto.dto.EffectMapper;
 import com.whbattle.springboot.usecase.weapon.dto.WeaponDto;
 import com.whbattle.springboot.usecase.weapon.dto.WeaponMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class UnitMapper {
@@ -15,9 +20,14 @@ public class UnitMapper {
     @Autowired
     private final WeaponMapper weaponMapper;
 
-    public UnitMapper(WeaponMapper weaponMapper) {
+    @Autowired
+    private final EffectMapper effectMapper;
+
+    public UnitMapper(WeaponMapper weaponMapper, EffectMapper effectMapper) {
         this.weaponMapper = weaponMapper;
+        this.effectMapper = effectMapper;
     }
+
     public Unit mapUnit(UnitDto unitDto) {
         return new Unit(
                 new DiceRoller(new Die()),
@@ -27,15 +37,20 @@ public class UnitMapper {
                 unitDto.wound,
                 unitDto.totalWounds,
                 mapWeapon(unitDto.weapon),
-                unitDto.reRoll);
+                unitDto.reRoll,
+                mapEffectList(unitDto.effects));
     }
 
     public Unit[] mapUnitList(UnitDto[] unitDtos) {
         Unit[] units = new Unit[unitDtos.length];
-        for(int i = 0;  i < unitDtos.length; i++) {
+        for (int i = 0; i < unitDtos.length; i++) {
             units[i] = this.mapUnit(unitDtos[i]);
         }
         return units;
+    }
+
+    public List<Effect> mapEffectList(EffectDto[] effectDtos) {
+        return effectMapper.mapEffectList(effectDtos);
     }
 
     private Weapon mapWeapon(WeaponDto weaponDto) {

--- a/src/test/java/com/whbattle/springboot/domain/unit/UnitTest.java
+++ b/src/test/java/com/whbattle/springboot/domain/unit/UnitTest.java
@@ -1,7 +1,8 @@
 package com.whbattle.springboot.domain.unit;
 
-import com.whbattle.springboot.domain.entity.dice.ReRoll;
 import com.whbattle.springboot.domain.entity.dice.DiceRoller;
+import com.whbattle.springboot.domain.entity.dice.ReRoll;
+import com.whbattle.springboot.domain.entity.unit.Effect;
 import com.whbattle.springboot.domain.entity.unit.Unit;
 import com.whbattle.springboot.domain.entity.unit.attack.Attack;
 import com.whbattle.springboot.domain.entity.unit.weapon.Weapon;
@@ -11,13 +12,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UnitTest {
-
-
-
     @Mock
     Weapon weapon;
 
@@ -28,13 +29,17 @@ public class UnitTest {
     Attack attack;
 
     @Mock
+    Effect effect;
+
+    @Mock
     DiceRoller diceRoller;
 
     Unit DEFAULT_UNIT;
 
     @Before
     public void setup() {
-       DEFAULT_UNIT = new Unit(diceRoller,"default unit", 20, 4, 4, 20, weapon, reRoll);
+        List<Effect> effects = Arrays.asList(effect);
+        DEFAULT_UNIT = new Unit(diceRoller, "default unit", 20, 4, 4, 20, weapon, reRoll, effects);
     }
 
     @Test
@@ -53,5 +58,13 @@ public class UnitTest {
         verify(weapon, times(1)).rollWounds(13, false, 0, 0);
     }
 
+    @Test
+    public void whenUnitHasEffectThatEndsOnSecondTurn_shouldDeactivateEffectAtStartOfSecondTurn() {
+        when(effect.getEndTurn()).thenReturn(2);
 
+        DEFAULT_UNIT.updateEffects(1);
+        DEFAULT_UNIT.updateEffects(2);
+
+        verify(effect, times(1)).setActive(false);
+    }
 }


### PR DESCRIPTION
By adding this property to POST /battle_report body, we can specify temporary modifiers to units :

```
{
    "effects": [{"toHitModifier": 1, "startTurn": 1, "endTurn": 2}]
}
```
